### PR TITLE
Assist gc and remove transactions.

### DIFF
--- a/lib/chain.js
+++ b/lib/chain.js
@@ -244,6 +244,7 @@ Chain.prototype._updateTip = function(block, callback) {
             return callback(err);
           }
 
+          delete self.tip.__transactions;
           self.tip = block;
           log.debug('Saving metadata');
           self.saveMetadata();


### PR DESCRIPTION
After syncing memory will grow without timely gc, removing this reference (`tip.__transactions`) helped with performance issues, as well as increasing the max old space size: 

```bash
node --max-old-space-size=8192 example.js
```